### PR TITLE
Adds the ability to use workshop as a type in the YAML Front Matter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ typings/
 
 # Snyk Code
 .dccache
+
+# Developing on a Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ You might wonder why is this referred to as a markdown file? because the front m
 
 #### type property
 
-There are currently 5 supported values for the `type` property within the YAML Front Matter.  The gigsboat cli will count how many of each of these exist, and create a badge with that count on the generated README.md file.
+There are currently 6 supported values for the `type` property within the YAML Front Matter.  The gigsboat cli will count how many of each of these exist, and create a badge with that count on the generated README.md file.
 
 These values are:
 
@@ -154,6 +154,9 @@ These values are:
 * webinar
 * meetup
 * article
+* workshop
+
+It is possible to use any free form text in the type property, however, when these aren't matched against the above, they will be counted in a fallback type called 'other'.
 
 ### gigsboat.json
 

--- a/__tests__/__snapshots__/main.test.js.snap
+++ b/__tests__/__snapshots__/main.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`given a directory of markdown files a full document is rendered 1`] = `
-"<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"></p>
+"<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"> </p>
 </div>
   
 # Table of Contents
@@ -13,7 +13,7 @@ exports[`given a directory of markdown files a full document is rendered 1`] = `
 # 2021
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square)
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square) 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
@@ -26,7 +26,7 @@ exports[`given a directory of markdown files a full document is rendered 1`] = `
 # 2019
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square) 
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square)  
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
@@ -41,7 +41,7 @@ exports[`given a directory of markdown files a full document is rendered 1`] = `
 `;
 
 exports[`given a directory of markdown files a full document is rendered along with pre and post content 1`] = `
-"<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"></p>
+"<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"> </p>
 </div>
   <p> actual html is allowed too </p>
 
@@ -57,7 +57,7 @@ Liran Tal
 # 2021
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square)
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square) 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
@@ -70,7 +70,7 @@ Liran Tal
 # 2019
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square) 
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square)  
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |

--- a/__tests__/__snapshots__/md-formatter.test.js.snap
+++ b/__tests__/__snapshots__/md-formatter.test.js.snap
@@ -13,12 +13,12 @@ exports[`process events json data to provide a complete markdown document 1`] = 
 
 
  - [Year of 2016](#2016) - total events 1
- - [Year of 2021](#2021) - total events 6
+ - [Year of 2021](#2021) - total events 8
 
 # 2016
 
 
-![Total Events](https://img.shields.io/badge/total-1-blue?style=flat-square)     
+![Total Events](https://img.shields.io/badge/total-1-blue?style=flat-square)      
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
@@ -29,7 +29,7 @@ exports[`process events json data to provide a complete markdown document 1`] = 
 # 2021
 
 
-![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-2-lightgrey?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square)
+![Total Events](https://img.shields.io/badge/total-8-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-2-lightgrey?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square) ![Total Workshops](https://img.shields.io/badge/workshops-2-orange?style=flat-square)
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
@@ -40,6 +40,8 @@ exports[`process events json data to provide a complete markdown document 1`] = 
 | 2021-2-2 | name | title |  | [Recording](https://example.com) | US | English |
 | 2021-2-2 | name | title |  | [Recording](https://example.com) | US | English |
 | 2021-2-2 | name | title |  | [Recording](https://example.com) | US | English |
+| 2021-2-2 | name | title |  | [Recording](https://example.com) | US | English |
+| 2021-2-3 | name | title |  | [Recording](https://example.com) | US | English |
 
 
 "

--- a/__tests__/md-formatter.test.js
+++ b/__tests__/md-formatter.test.js
@@ -108,15 +108,40 @@ test('process events json data to provide a complete markdown document', () => {
             country_code: 'US',
             language: 'English'
           }
+        },
+        {
+          attributes: {
+            date: new Date('2021-02-02'),
+            title: 'title',
+            type: 'workshop',
+            name: 'name',
+            slides_url: null,
+            recording_url: 'https://example.com',
+            country_code: 'US',
+            language: 'English'
+          }
+        },
+        {
+          attributes: {
+            date: new Date('2021-02-03'),
+            title: 'title',
+            type: 'workshop',
+            name: 'name',
+            slides_url: null,
+            recording_url: 'https://example.com',
+            country_code: 'US',
+            language: 'English'
+          }
         }
       ],
       stats: {
-        total: 6,
+        total: 8,
         total_podcast: 1,
         total_conference: 1,
         total_webinar: 2,
         total_meetup: 1,
         total_article: 1,
+        total_workshop: 2,
         total_other: 0
       }
     }

--- a/src/utils/content-manager.js
+++ b/src/utils/content-manager.js
@@ -16,6 +16,7 @@ function getEventsStats(entries) {
     total_webinar: 0,
     total_meetup: 0,
     total_article: 0,
+    total_workshop: 0,
     total_other: 0
   }
 
@@ -33,6 +34,8 @@ function getEventsStats(entries) {
       stats.total_meetup += 1
     } else if (type === 'article') {
       stats.total_article += 1
+    } else if (type === 'workshop') {
+      stats.total_workshop += 1
     } else {
       stats.total_other += 1
     }

--- a/src/utils/md-formatter.js
+++ b/src/utils/md-formatter.js
@@ -56,6 +56,9 @@ export function getStatsBadges(events) {
   const badgeForTotalArticles = events.stats.total_article
     ? `![Total Podcasts](https://img.shields.io/badge/articles-${events.stats.total_article}-green?style=flat-square)`
     : 0
+  const badgeForTotalWorkshops = events.stats.total_workshop
+    ? `![Total Workshops](https://img.shields.io/badge/workshops-${events.stats.total_workshop}-orange?style=flat-square)`
+    : 0
 
   statsBadges.push({
     p: `${badgeForTotalEvents ? badgeForTotalEvents : ''} ${
@@ -64,7 +67,7 @@ export function getStatsBadges(events) {
       badgeForTotalPodcasts ? badgeForTotalPodcasts : ''
     } ${badgeForTotalWebinars ? badgeForTotalWebinars : ''} ${
       badgeForTotalArticles ? badgeForTotalArticles : ''
-    }`
+    } ${badgeForTotalWorkshops ? badgeForTotalWorkshops : ''}`
   })
 
   return json2md(statsBadges) + '\n'


### PR DESCRIPTION
## Description

This PR adds the ability to use `workshop` as a type in the YAML Front matter for a speaking engagement.  This works in exactly the same way as the other groupings work.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes #17

## Motivation and Context

I have a couple of events that were in the style of a workshop, and I would like to be able to call them out specifically, rather than having them land in the `other` category.

## How Has This Been Tested?

I have updated the existing unit test snapshots to account for the changes in the output.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

My dog Bailey...

![2021-12-03_07-29-55](https://user-images.githubusercontent.com/1271146/144562737-616031c9-1fa5-44f3-9466-6160b7053e9b.png)
