### PR TITLE
feat: yaml config options for html generation using liquid templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ This is the configuration file for the gigsboat CLI.  This contains four section
   * `sourceDirectory` - this is the relative path to the directory in which the data files for the generated file are located
 * `output`
   * `markdownFile` - this is the name of the file that should be generated
-* `preContent` - a collection of raw or formatted HTML to place at the start of the generated file
+* `metadata` - an object containing YAML Front Matter metadata which will be placed at the top of the generated file but not visible on a markdown preview
+* `preContent` - a collection of raw or formatted HTML to place at the start of the generated file preview, after the `meatadata` if any
 * `postContent` - a collection of raw or formatted HTML to place at the end of the generated file
 
 A complete example of this configuration file:
@@ -179,9 +180,13 @@ A complete example of this configuration file:
   "output": {
     "markdownFile": "README-gigs.md"
   },
+  "metadata": {
+    "title": "This will appear as metadata on the top of the generated README.md file and it won't be visible in the file preview, but it can be used with a liquid template",
+    "layout": "You can define the name of a layout file which can be used with a liquid template and a static site generator like [11ty](https://www.11ty.dev/) or [jekyll](https://jekyllrb.com/)"
+  },
   "preContent": [
     {
-      "raw": "<p align='center'><h1 align='center'>This will appear at the top of the generated README.md file</h1>"
+      "raw": "<p align='center'><h1 align='center'>This will appear at the top of the preview of the generated README.md file</h1>"
     },
     {
       "raw": "<p align='center'>Let's add some badges! <p align='center'><a href='https://twitter.com/liran_tal'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/liran_tal?style=social'></a></p>"

--- a/__tests__/__snapshots__/main.test.js.snap
+++ b/__tests__/__snapshots__/main.test.js.snap
@@ -89,3 +89,106 @@ Thank you!
 
 <i>Updated on 2021-12-14T00:00:00.000Z</i>"
 `;
+
+exports[`given a directory of markdown files a full document is rendered with any yaml metadata passed 1`] = `
+"---
+title: a title
+description: decsription of document
+randomProp: a random prop description
+randomPropNumber: 5
+---
+<!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->
+<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"> </p>
+</div>
+  
+# Table of Contents
+
+
+ - [Year of 2021](#2021) - total events 3
+ - [Year of 2019](#2019) - total events 3
+
+# 2021
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square) 
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2021-7-21 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](myapp/pages/2021/2021-07-21.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+| 2021-6-13 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](myapp/pages/2021/2021-06-13.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+| 2021-1-1 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](myapp/pages/2021/2021-01-01.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+
+
+# 2019
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square)  
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2019-9-27 | JSConf Budapest | [StrangerDanger: Finding Security Vulnerabilities Before They Find You!](myapp/pages/2019/2019-09-27.md) |  | [Recording](https://www.youtube.com/watch?v=3H8pF6yoSgU&list=PL37ZVnwpeshEMCvdYDdZ09Sy-toTftWu0&index=15&ab_channel=JSConf) | HU | English |
+| 2019-9-15 | JSConf Budapest | [StrangerDanger: Finding Security Vulnerabilities Before They Find You!](myapp/pages/2019/2019-09-15.md) |  | [Recording](https://www.youtube.com/watch?v=3H8pF6yoSgU&list=PL37ZVnwpeshEMCvdYDdZ09Sy-toTftWu0&index=15&ab_channel=JSConf) | HU | English |
+| 2019-9-12 | APIdays Barcelona | [Consumer-Driven Contracts: A better approach for API Testing](myapp/pages/2019/2019-09-12.md) | [Slides](https://slides.com/lirantal/consumer-driven-contracts) | [Recording](https://www.youtube.com/watch?v=zfGKX5iKSis&list=PLmEaqnTJ40Oqo9VlbcUakVmFZgx5weLrs&index=25&t=141s&ab_channel=apidays) | ES | English |
+
+
+
+
+<i>Updated on 2021-12-14T00:00:00.000Z</i>"
+`;
+
+exports[`given a directory of markdown files a full document is rendered with any yaml metadata passed along with pre and post content 1`] = `
+"---
+title: a title
+description: decsription of document
+layout: layoutFileName
+---
+<!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->
+<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"> </p>
+</div>
+  <p> actual html is allowed too </p>
+
+Liran Tal
+
+
+# Table of Contents
+
+
+ - [Year of 2021](#2021) - total events 3
+ - [Year of 2019](#2019) - total events 3
+
+# 2021
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square) 
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2021-7-21 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](myapp/pages/2021/2021-07-21.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+| 2021-6-13 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](myapp/pages/2021/2021-06-13.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+| 2021-1-1 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](myapp/pages/2021/2021-01-01.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | IL | English |
+
+
+# 2019
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square)  
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2019-9-27 | JSConf Budapest | [StrangerDanger: Finding Security Vulnerabilities Before They Find You!](myapp/pages/2019/2019-09-27.md) |  | [Recording](https://www.youtube.com/watch?v=3H8pF6yoSgU&list=PL37ZVnwpeshEMCvdYDdZ09Sy-toTftWu0&index=15&ab_channel=JSConf) | HU | English |
+| 2019-9-15 | JSConf Budapest | [StrangerDanger: Finding Security Vulnerabilities Before They Find You!](myapp/pages/2019/2019-09-15.md) |  | [Recording](https://www.youtube.com/watch?v=3H8pF6yoSgU&list=PL37ZVnwpeshEMCvdYDdZ09Sy-toTftWu0&index=15&ab_channel=JSConf) | HU | English |
+| 2019-9-12 | APIdays Barcelona | [Consumer-Driven Contracts: A better approach for API Testing](myapp/pages/2019/2019-09-12.md) | [Slides](https://slides.com/lirantal/consumer-driven-contracts) | [Recording](https://www.youtube.com/watch?v=zfGKX5iKSis&list=PLmEaqnTJ40Oqo9VlbcUakVmFZgx5weLrs&index=25&t=141s&ab_channel=apidays) | ES | English |
+
+
+
+<p align=\\"center\\"> rendered in postcontent </p>
+
+Thank you!
+
+
+<i>Updated on 2021-12-14T00:00:00.000Z</i>"
+`;

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -49,3 +49,54 @@ test('given a directory of markdown files a full document is rendered along with
   })
   expect(jsonResult).toMatchSnapshot()
 })
+
+test('given a directory of markdown files a full document is rendered with any yaml metadata passed', async () => {
+  const filePath = path.join(__dirname, './__fixtures__/main-datafiles')
+  const jsonResult = await generateDocument({
+    sourceDirectory: filePath,
+    metadata: {
+      title: 'a title',
+      description: 'decsription of document',
+      randomProp: 'a random prop description',
+      randomPropNumber: 5
+    }
+  })
+  expect(jsonResult).toMatchSnapshot()
+})
+
+test('given a directory of markdown files a full document is rendered with any yaml metadata passed along with pre and post content', async () => {
+  const filePath = path.join(__dirname, './__fixtures__/main-datafiles')
+  const jsonResult = await generateDocument({
+    sourceDirectory: filePath,
+    preContent: [
+      {
+        raw: '<p> actual html is allowed too </p>'
+      },
+      {
+        format: [
+          {
+            p: 'Liran Tal'
+          }
+        ]
+      }
+    ],
+    postContent: [
+      {
+        raw: '<p align="center"> rendered in postcontent </p>'
+      },
+      {
+        format: [
+          {
+            p: 'Thank you!'
+          }
+        ]
+      }
+    ],
+    metadata: {
+      title: 'a title',
+      description: 'decsription of document',
+      layout: 'layoutFileName'
+    }
+  })
+  expect(jsonResult).toMatchSnapshot()
+})

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import { getConfig } from './config-manager.js'
 import { processOutput } from './output-handler.js'
-import { generateDocument } from '../src/main.js'
+import { generateDocument, generateEleventyDocument } from '../src/main.js'
 
 let gigsConfig = await getConfig()
+
+const shouldGenerateEleventy = process.argv.includes('--eleventy')
 
 const document = await generateDocument({
   sourceDirectory: gigsConfig.input.sourceDirectory,
@@ -11,4 +13,20 @@ const document = await generateDocument({
   postContent: gigsConfig.postContent
 })
 
-await processOutput({ document, outputFile: gigsConfig.output.markdownFile })
+const eleventyDocument = shouldGenerateEleventy
+  ? generateEleventyDocument({
+      document,
+      config: {
+        title: gigsConfig.eleventy.title,
+        description: gigsConfig.eleventy.description,
+        layout: gigsConfig.eleventy.layout
+      }
+    })
+  : null
+
+await processOutput({
+  document,
+  outputFile: gigsConfig.output.markdownFile,
+  eleventyDocument,
+  eleventyOutputFile: `${gigsConfig.eleventy.inputDir}/index.md`
+})

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,32 +1,15 @@
 #!/usr/bin/env node
 import { getConfig } from './config-manager.js'
 import { processOutput } from './output-handler.js'
-import { generateDocument, generateEleventyDocument } from '../src/main.js'
+import { generateDocument } from '../src/main.js'
 
 let gigsConfig = await getConfig()
-
-const shouldGenerateEleventy = process.argv.includes('--eleventy')
 
 const document = await generateDocument({
   sourceDirectory: gigsConfig.input.sourceDirectory,
   preContent: gigsConfig.preContent,
-  postContent: gigsConfig.postContent
+  postContent: gigsConfig.postContent,
+  metadata: gigsConfig.metadata
 })
 
-const eleventyDocument = shouldGenerateEleventy
-  ? generateEleventyDocument({
-      document,
-      config: {
-        title: gigsConfig.eleventy.title,
-        description: gigsConfig.eleventy.description,
-        layout: gigsConfig.eleventy.layout
-      }
-    })
-  : null
-
-await processOutput({
-  document,
-  outputFile: gigsConfig.output.markdownFile,
-  eleventyDocument,
-  eleventyOutputFile: `${gigsConfig.eleventy.inputDir}/index.md`
-})
+await processOutput({ document, outputFile: gigsConfig.output.markdownFile })

--- a/bin/output-handler.js
+++ b/bin/output-handler.js
@@ -4,9 +4,21 @@ import path from 'path'
 
 const __dirname = process.cwd()
 
-export async function processOutput({ document, outputFile }) {
+export async function processOutput({
+  document,
+  outputFile,
+  eleventyDocument,
+  eleventyOutputFile
+}) {
   if (outputFile) {
     await fs.writeFile(path.join(__dirname, outputFile), document)
+
+    if (eleventyDocument) {
+      await fs.writeFile(
+        path.join(__dirname, eleventyOutputFile),
+        eleventyDocument
+      )
+    }
   } else {
     console.log(document)
   }

--- a/bin/output-handler.js
+++ b/bin/output-handler.js
@@ -4,21 +4,9 @@ import path from 'path'
 
 const __dirname = process.cwd()
 
-export async function processOutput({
-  document,
-  outputFile,
-  eleventyDocument,
-  eleventyOutputFile
-}) {
+export async function processOutput({ document, outputFile }) {
   if (outputFile) {
     await fs.writeFile(path.join(__dirname, outputFile), document)
-
-    if (eleventyDocument) {
-      await fs.writeFile(
-        path.join(__dirname, eleventyOutputFile),
-        eleventyDocument
-      )
-    }
   } else {
     console.log(document)
   }

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,12 @@ import {
 } from './utils/md-formatter.js'
 import { createYearBuckets, getEventsStats } from './utils/content-manager.js'
 
-export { formatToMarkdown, generateGigs, generateDocument }
+export {
+  formatToMarkdown,
+  generateGigs,
+  generateDocument,
+  generateEleventyDocument
+}
 
 async function generateDocument({ sourceDirectory, preContent, postContent }) {
   let markdownOutputPreContent = ''
@@ -52,6 +57,31 @@ async function generateDocument({ sourceDirectory, preContent, postContent }) {
     footer
 
   return document
+}
+
+function generateEleventyDocument({ document, config }) {
+  const { title, description, layout } = config
+  const configDelimiter = '---'
+  const warning = '<!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->'
+
+  let eleventyDocument = ''
+
+  eleventyDocument +=
+    configDelimiter +
+    '\n' +
+    `title: ${title}` +
+    '\n' +
+    `description: ${description}` +
+    '\n' +
+    `layout: ${layout}` +
+    '\n' +
+    configDelimiter +
+    '\n' +
+    warning +
+    '\n' +
+    document
+
+  return eleventyDocument
 }
 
 function processCustomContent({ contents }) {

--- a/src/main.js
+++ b/src/main.js
@@ -10,14 +10,15 @@ import {
 } from './utils/md-formatter.js'
 import { createYearBuckets, getEventsStats } from './utils/content-manager.js'
 
-export {
-  formatToMarkdown,
-  generateGigs,
-  generateDocument,
-  generateEleventyDocument
-}
+export { formatToMarkdown, generateGigs, generateDocument }
 
-async function generateDocument({ sourceDirectory, preContent, postContent }) {
+async function generateDocument({
+  sourceDirectory,
+  preContent,
+  postContent,
+  metadata
+}) {
+  let yamlMetadata = ''
   let markdownOutputPreContent = ''
   let markdownOutputPostContent = ''
   let document = ''
@@ -25,6 +26,10 @@ async function generateDocument({ sourceDirectory, preContent, postContent }) {
   const { entriesForYearMarkdown, entriesByBucket } = await generateGigs({
     sourceDirectory
   })
+
+  if (metadata) {
+    yamlMetadata = generateMetadata(metadata)
+  }
 
   if (preContent) {
     markdownOutputPreContent = processCustomContent({
@@ -47,6 +52,7 @@ async function generateDocument({ sourceDirectory, preContent, postContent }) {
   const footer = `<i>Updated on ${currentDate}</i>`
 
   document +=
+    yamlMetadata +
     statsHeader +
     markdownOutputPreContent +
     '\n' +
@@ -59,29 +65,22 @@ async function generateDocument({ sourceDirectory, preContent, postContent }) {
   return document
 }
 
-function generateEleventyDocument({ document, config }) {
-  const { title, description, layout } = config
-  const configDelimiter = '---'
-  const warning = '<!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->'
+function generateMetadata(metadata) {
+  const delimiter = '---'
+  const warning =
+    '<!-- DO NOT EDIT! THIS FILE WILL BE OVERRIDDEN BY THE GIGSBOAT SCRIPT -->'
 
-  let eleventyDocument = ''
+  let yamlMetadata = ''
 
-  eleventyDocument +=
-    configDelimiter +
-    '\n' +
-    `title: ${title}` +
-    '\n' +
-    `description: ${description}` +
-    '\n' +
-    `layout: ${layout}` +
-    '\n' +
-    configDelimiter +
-    '\n' +
-    warning +
-    '\n' +
-    document
+  yamlMetadata += delimiter + '\n'
 
-  return eleventyDocument
+  for (const key in metadata) {
+    yamlMetadata += `${key}: ${metadata[key]}\n`
+  }
+
+  yamlMetadata += delimiter + '\n' + warning + '\n'
+
+  return yamlMetadata
 }
 
 function processCustomContent({ contents }) {


### PR DESCRIPTION
## Description

This is a first draft for the potential implementation of issue #24 on which I'd like to get some feedback.
The solution is very simple (maybe too simple?). I added the option to have some YAML metadata at the top of the generated readme, which can assist us in the usage of a liquid template.

This change is accompanied by changes to the gigsboat/template [PR](https://github.com/gigsboat/gigs-eleventy-template/pull/3/files) in order to give some defaults for an eleventy starter. Maybe it would be even better if we created a new _gigs-eleventy-template_ but for now the PR is based on the original. More details for the template changes will be in the relevant PR.

I tried to be as consisted as possible with the current implementation. Atm, this approach doesn't give full flexibility on the html produced, but I didn't want to deviate too much from the current. Hence, the contents of the document are not editable. If a JSON output is eventually implemented, this approach could change to give more flexible options.

Alternatively, I can use the `pages` files as the source of truth and create completely new methods for the html (or liquid template, or other eleventy compatible) file creation but I decided to go with the simplest option to start with, in order to not add too much to the existing code.

This simple approach also gives flexibility to use any html generator, not just eleventy. (ie: it is compatible with jekyll)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
#24 

## Motivation and Context
We can generate html in order to display gigs on a different format

## How Has This Been Tested?
Locally on macOS and with a [github pages deployment](https://estherixz.github.io/gigs-template/)
Existing tests are passing as expected and new tests have been added for the metadata config. There is an action that runs on the new template which demonstrates the steps to generate an html using eleventy.

## Screenshots (if appropriate):
<img width="1065" alt="Screenshot 2022-01-25 at 12 43 39" src="https://user-images.githubusercontent.com/8407403/150971452-e7ec05ad-78ca-4177-b793-e0993816b6e4.png">

## Checklist:
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of ~a cute~ 11 grumpy animal(s) cause it's fun

![11 cats](https://user-images.githubusercontent.com/8407403/150971438-d2083050-f712-4bd9-8873-7c96090a005e.jpg)