### PR TITLE
chore: document steps to deploy to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ Use npm's built-in `npx` command to fetch, install, and run gigsboat with no con
 npx @gigsboat/cli
 ```
 
+## Deploying to github pages
+It is possible to deploy the generated README.md file to github pages. All that is needed, is to enable github-pages in the repository's *settings* > *pages*, as is described in the [github pages docs](https://docs.github.com/en/pages/quickstart#creating-your-website), starting from _step 3_. 
+
+To access the generated site visit
+`https://<username-or-org>.github.io/<template-repo-name>`
+
+To select a different theme than the default or to customise it, add a __config.yml_ file and include `theme: jekyll-theme-minimal`. From the same __config.yml_ file, it's also possible to set a `title` and `description` for the gerated html. For more details on theme customisation follow the steps described in [adding a theme to your jekyll site](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll).
+
 # Contributing
 
 Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing to this project.


### PR DESCRIPTION
## Description
Added documentation for deploying the generated README file to github pages.

## Types of changes
- [x] Docs update

## Related Issue
#24 

## Motivation and Context
Provide easy steps to deploy to github pages

## How Has This Been Tested?
Manually with a github pages deployment

## Screenshots (if appropriate):
Minimal theme
<img width="400" alt="Screenshot 2022-01-28 at 16 58 20" src="https://user-images.githubusercontent.com/8407403/151579776-2194373e-9bd6-4f91-86cd-73c6646aabcd.png">

Midnight theme
<img width="400" alt="Screenshot 2022-01-28 at 17 00 33" src="https://user-images.githubusercontent.com/8407403/151579947-4c12cdfc-5abf-4050-96b8-e1b30e5496d3.png">

## Checklist:
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
