### PR TITLE
test: extend e2e tests to include matching the markdown file

### DIFF
--- a/__tests__/__snapshots__/main-e2e.test.js.snap
+++ b/__tests__/__snapshots__/main-e2e.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`spawn the cli to process data and ensure markdown file is generated correctly 1`] = `
+"<div align='center'><p><img src=\\"https://img.shields.io/badge/total-6-blue?style=flat-square\\" alt=\\"Total Events\\"> <img src=\\"https://img.shields.io/badge/meetups-1-violet?style=flat-square\\" alt=\\"Total Meetups\\"> <img src=\\"https://img.shields.io/badge/conferences-1-red?style=flat-square\\" alt=\\"Total Conferences\\"> <img src=\\"https://img.shields.io/badge/podcasts-1-yellow?style=flat-square\\" alt=\\"Total Podcasts\\"> <img src=\\"https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square\\" alt=\\"Total Webinars\\"> <img src=\\"https://img.shields.io/badge/articles-1-green?style=flat-square\\" alt=\\"Total Podcasts\\"> </p>
+</div>
+  
+# Table of Contents
+
+
+ - [Year of 2021](#2021) - total events 3
+ - [Year of 2019](#2019) - total events 3
+
+# 2021
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square)   ![Total Podcasts](https://img.shields.io/badge/articles-1-green?style=flat-square) 
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2021-7-21 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](2021/2021-07-21.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | [🇮🇱](## \\"Israel\\") | English |
+| 2021-6-13 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](2021/2021-06-13.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | [🇮🇱](## \\"Israel\\") | English |
+| 2021-1-1 | Cyber Week | [Are We Forever Doomed By Software Supply Chain Risks?](2021/2021-01-01.md) |  | [Recording](https://www.youtube.com/watch?v=x74sMCaZKbg&ab_channel=Snyk) | [🇮🇱](## \\"Israel\\") | English |
+
+
+# 2019
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square)  ![Total Podcasts](https://img.shields.io/badge/podcasts-1-yellow?style=flat-square) ![Total Webinars](https://img.shields.io/badge/webinars-1-lightgrey?style=flat-square)  
+
+
+<table>
+  <tr>
+    <td align=\\"center\\"> <img src=\\"https://pbs.twimg.com/media/EFeULhIW4AARwZa?format=jpg&name=large\\" width=\\"85\\" height=\\"50\\" /> </td>
+    <td align=\\"center\\"> <img src=\\"https://pbs.twimg.com/media/EFeULhIW4AARwZa?format=jpg&name=large\\" width=\\"85\\" height=\\"50\\" /> </td>
+    <td align=\\"center\\"> <img src=\\"https://pbs.twimg.com/media/EEQPqXlXUAEoafi?format=jpg&name=large\\" width=\\"85\\" height=\\"50\\" /> </td>
+    <td align=\\"center\\"> <img src=\\"https://pbs.twimg.com/media/ECJ2Zv6WsAEPUFF?format=jpg&name=large\\" width=\\"85\\" height=\\"50\\" /> </td>
+  </tr>
+</table>
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2019-9-27 | JSConf Budapest | [StrangerDanger: Finding Security Vulnerabilities Before They Find You!](2019/2019-09-27.md) |  | [Recording](https://www.youtube.com/watch?v=3H8pF6yoSgU&list=PL37ZVnwpeshEMCvdYDdZ09Sy-toTftWu0&index=15&ab_channel=JSConf) | [🇭🇺](## \\"Hungary\\") | English |
+| 2019-9-15 | JSConf Budapest | [StrangerDanger: Finding Security Vulnerabilities Before They Find You!](2019/2019-09-15.md) |  | [Recording](https://www.youtube.com/watch?v=3H8pF6yoSgU&list=PL37ZVnwpeshEMCvdYDdZ09Sy-toTftWu0&index=15&ab_channel=JSConf) | [🇭🇺](## \\"Hungary\\") | English |
+| 2019-9-12 | APIdays Barcelona | [Consumer-Driven Contracts: A better approach for API Testing](2019/2019-09-12.md) | [Slides](https://slides.com/lirantal/consumer-driven-contracts) | [Recording](https://www.youtube.com/watch?v=zfGKX5iKSis&list=PLmEaqnTJ40Oqo9VlbcUakVmFZgx5weLrs&index=25&t=141s&ab_channel=apidays) | [🇪🇸](## \\"Spain\\") | English |
+
+
+
+
+powered by [gigsboat/cli](https://github.com/gigsboat/cli)"
+`;

--- a/__tests__/main-e2e.test.js
+++ b/__tests__/main-e2e.test.js
@@ -1,6 +1,6 @@
 import { spawnSync } from 'child_process';
 import { tmpdir } from 'os';
-import { unlinkSync } from 'fs'
+import { unlinkSync, readFileSync } from 'fs'
 import path from 'path';
 
 const __dirname = new URL('.', import.meta.url).pathname
@@ -10,13 +10,23 @@ test('spawn the cli to process data and ensure markdown file is generated correc
     const projectFixtures = path.join(__dirname, './__fixtures__/main-datafiles/myapp/pages')
     const projectOutputFile = path.join(tmpdir(), 'test.md')
 
-    const cliData = spawnSync(cliExecutable, ['--source-directory', projectFixtures, '--output-file', projectOutputFile], { shell: true});
+    
+    // specifically need to mutate the process.argv array to avoid the cli
+    // generating an "updated at" timestamp so we can always match the snapshot
+    // and so we add a TEST_E2E flag to it
+    const spawnedCliEnvironmentVariables = process.env
+    spawnedCliEnvironmentVariables.TEST_E2E = 'true'
+
+    const cliData = spawnSync(cliExecutable, ['--source-directory', projectFixtures, '--output-file', projectOutputFile], { shell: true, env: spawnedCliEnvironmentVariables})
 
     const cliOutput = cliData.output.toString();
     
     expect(cliOutput).toContain('loaded configuration:')
     expect(cliOutput).toContain('source directory: ' + projectFixtures)
     expect(cliOutput).toContain('output file: ' + projectOutputFile)
+
+    const expectedMarkdownOutput = readFileSync(projectOutputFile, 'utf8')
+    expect(expectedMarkdownOutput).toMatchSnapshot()
 
     // cleanup temporary files
     unlinkSync(projectOutputFile)

--- a/src/main.js
+++ b/src/main.js
@@ -49,7 +49,9 @@ async function generateDocument({ sourceDirectory, preContent, postContent }) {
 
   const currentDate = new Date().toISOString()
   let footer = ''
-  footer += `*page updated on ${currentDate}*\n\n`
+  if (!process.env.TEST_E2E) {
+    footer += `*page updated on ${currentDate}*\n\n`
+  }
   footer += `powered by [gigsboat/cli](https://github.com/gigsboat/cli)`
 
   document +=


### PR DESCRIPTION
Add a specific TEST_E2E flag to the generated file to indicate
that timestamps shouldn't be generated in the output file so
that we can always use the .toMatchSnapshot() assertion for
the entire contents of the file.
